### PR TITLE
Update CI to run lint also

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,12 @@
+[flake8]
+extend-ignore = E203, W391
+exclude =
+    .git,
+    __pycache__,
+    docs/source/conf.py,
+    old,
+    build,
+    dist,
+    .venv
+max-complexity = 10
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,8 +6,11 @@ jobs:
   web:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
-      - name: Build the docker image
-        run: docker-compose build
-      - name: Use pytest to execute the tests
-        run: docker-compose run web pytest
+      - uses: actions/checkout@v3
+      - name: Install Requirements
+        run: pip install -r requirements.txt
+      - name: Run Linter on python code with flake8
+        run: flake8
+      - name: Use pytest to run unittests
+        run: pytest
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,8 @@
 fastapi==0.68.1
 uvicorn==0.15.0
 GoogleNews==1.6.6
+
 # Test packages
 pytest==6.2.5
+flake8==6.0.0
 requests


### PR DESCRIPTION
- Added Flake8 for linter purposes
- Instead of creating a docker image, installs everything on CI environment and runs pytest